### PR TITLE
Support multiple ingress controllers

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -6,7 +6,8 @@
 {{- $uiSvcPort := .Values.service.uiPort -}}
 {{- $restSvcPort := .Values.service.restPort -}}
 {{- $grpcSvcPort := .Values.service.grpcPort -}}
-{{- $classname := required "A valid .Values.ingress.className entry required! Please set this to your ingress class (nginx, traefik)" .Values.ingress.className}}
+{{- $classname := required "A valid .Values.ingress.className entry required! Please set this to your ingress class (nginx, nginx-<name>, traefik)" .Values.ingress.className}}
+{{- $ingressType := required "A valid .Values.ingress.type entry required! Please set this to your ingress type (nginx, traefik)" .Values.ingress.type}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
@@ -27,10 +28,15 @@ metadata:
   {{- with .Values.ingress }}
   annotations:
     {{- toYaml .annotations.base | nindent 4 }}
-    {{- if or (eq .className "nginx") (eq .className "public") }}
+    {{- if or (eq $ingressType "nginx") (eq .className "public") }}
     {{- toYaml .annotations.nginx | nindent 4 }}
+    {{- if .annotations.ui }}
+    {{- if .annotations.ui.nginx }}
+    {{- toYaml .annotations.ui.nginx | nindent 4 }}
     {{- end }}
-    {{- if eq .className "traefik" }}
+    {{- end }}
+    {{- end }}
+    {{- if eq $ingressType "traefik" }}
     {{- toYaml .annotations.traefik | nindent 4 }}
     {{- end }}
     {{- if and .tls.enabled (eq .tls.issuerName "" )}}
@@ -40,7 +46,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- if (not (eq .Values.ingress.className "traefik")) }}
+  {{- if (not (eq $ingressType "traefik")) }}
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ required "A valid .Values.ingress.className entry required!" .Values.ingress.className}}
   {{- end }}
@@ -85,10 +91,10 @@ metadata:
   {{- with .Values.ingress }}
   annotations:
     {{- toYaml .annotations.base | nindent 4 }}
-    {{- if or (eq .className "nginx") (eq .className "public") }}
+    {{- if or (eq $ingressType "nginx") (eq .className "public") }}
     {{- toYaml .annotations.nginx | nindent 4 }}
     {{- end }}
-    {{- if eq .className "traefik" }}
+    {{- if eq $ingressType "traefik" }}
     {{- toYaml .annotations.traefik | nindent 4 }}
     {{- end }}
     {{- if and .tls.enabled (eq .tls.issuerName "" )}}
@@ -98,7 +104,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- if (not (eq .Values.ingress.className "traefik")) }}
+  {{- if (not (eq $ingressType "traefik")) }}
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName:  {{ required "A valid .Values.ingress.className entry required!" .Values.ingress.className}}
   {{- end }}
@@ -128,7 +134,7 @@ spec:
               servicePort: {{ $restSvcPort }}
               {{- end }}
 ---
-{{- if not (eq .Values.ingress.className "traefik") }}
+{{- if not (eq $ingressType "traefik") }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
 {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -144,11 +150,11 @@ metadata:
   {{- with .Values.ingress }}
   annotations:
     {{- toYaml .annotations.base | nindent 4 }}
-    {{- if or (eq .className "nginx") (eq .className "public") }}
+    {{- if or (eq $ingressType "nginx") (eq .className "public") }}
     {{- toYaml .annotations.nginx | nindent 4 }}
     {{- toYaml .annotations.grpc.nginx | nindent 4 }}
     {{- end }}
-    {{- if eq .className "traefik" }}
+    {{- if eq $ingressType "traefik" }}
     {{- toYaml .annotations.traefik | nindent 4 }}
     {{- end }}
     {{- if and .tls.enabled (eq .tls.issuerName "" )}}
@@ -158,7 +164,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- if (not (eq .Values.ingress.className "traefik")) }}
+  {{- if (not (eq $ingressType "traefik")) }}
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName:  {{ required "A valid .Values.ingress.className entry required!" .Values.ingress.className}}
   {{- end }}
@@ -188,7 +194,7 @@ spec:
               servicePort: {{ $grpcSvcPort }}
               {{- end }}
 {{- end }}
-{{- if eq .Values.ingress.className "traefik" }}
+{{- if eq $ingressType "traefik" }}
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteTCP

--- a/values.yaml
+++ b/values.yaml
@@ -54,6 +54,8 @@ service:
 ingress:
   # -- attempts to configure ingress if true
   enabled: false
+  # -- type of ingress, either "nginx" or "traefik"
+  type: nginx
   tls:
     enabled: true
     issuerName: "letsencrypt-prod"
@@ -61,6 +63,9 @@ ingress:
     base:
       # -- annotation to generate ACME certs if available
       kubernetes.io/ingress.allow-http: "false"    
+    ui:
+      # -- Optional: additional annotations for nginx UI ingress
+      nginx: {}
     tls:
       # -- use acme cert if available
       kubernetes.io/tls-acme: "true"

--- a/values.yaml
+++ b/values.yaml
@@ -51,7 +51,12 @@ service:
   # -- port for UI service
   uiPort: 80
 
+# -- FQDN suffix appended to URLs in statefulset and ingress, e.g. test.com
+baseDomain: ""
+
 ingress:
+  # -- class name of ingress, e.g. nginx-external
+  className: ""
   # -- attempts to configure ingress if true
   enabled: false
   # -- type of ingress, either "nginx" or "traefik"


### PR DESCRIPTION
Currently, the ingress-controller's className must be exactly "nginx" or "traefik" because the type comparison is being made against the ingress className.

This PR introduces a new ingressType variable to switch between nginx or traefik and allows the original ingressClass to be configurable (to support multiple ingress controllers).