### PR TITLE
Bugfix: duplicate name attribute in mqtt template

### DIFF
--- a/templates/mq.yaml
+++ b/templates/mq.yaml
@@ -38,7 +38,6 @@ spec:
           tcpSocket:
             port: 8883
           timeoutSeconds: 1
-        name: mosquitto
         ports:
         - containerPort: 1883        
           name: mqtt


### PR DESCRIPTION
Hi,

There is a duplicate "name" attribute in the MQTT helm template.

Helm is not complaining about it, but kustomize does.

Regards
André