### PR TITLE
Fix enabled flag and make RWX storageClassName consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ helm install netmaker/netmaker --generate-name \ # generate a random id for the 
 
 ### Recommended Settings:
 A minimal HA install of Netmaker can be run with the following command:
-`helm install netmaker/netmaker --generate-name --set baseDomain=nm.example.com --set RWXStorageClassName=nfs`
+`helm install netmaker/netmaker --generate-name --set baseDomain=nm.example.com --set mq.RWX.storageClassName=nfs`
 `
 This install has some notable exceptions:
 - Ingress **must** be manually configured post-install (need to create valid Ingress with TLS)

--- a/templates/mq.yaml
+++ b/templates/mq.yaml
@@ -110,7 +110,7 @@ apiVersion: v1
 metadata:
   name: {{ include "netmaker.fullname" . }}-shared-data-pvc
 spec:
-  storageClassName: {{ required "A valid .Values.RWXStorageClassName entry required! Specify an available RWX storage class." .Values.RWXStorageClassName}}
+  storageClassName: {{ required "A valid .Values.mq.RWX.storageClassName entry required! Specify an available RWX storage class." .Values.mq.RWX.storageClassName}}
   accessModes:
     - ReadWriteMany
   resources:

--- a/values.yaml
+++ b/values.yaml
@@ -44,12 +44,15 @@ mq:
   singlenode: false
   storageSize: 128Mi
   password: 3yyerWGdds43yegGR
-
+  RWX:
+    storageClassName: ""
 
 dns:
   # -- whether or not to deploy coredns
   enabled: false
   storageSize: 128Mi
+  RWX:
+    storageClassName: ""
 
 setIpForwarding:
   enabled: true
@@ -112,6 +115,7 @@ wireguard:
   networkLimit: 10
 
 postgresql-ha:
+  enabled: true
   postgresql:
     # -- postgres user to generate
     username: netmaker
@@ -121,7 +125,6 @@ postgresql-ha:
     database: netmaker
     # -- postgress number of replicas to deploy
     replicaCount: 2
-    enabled: true
   persistence:
     # -- size of postgres DB
     size: 1Gi


### PR DESCRIPTION
Renamed `.Values.RWXStorageClassName` to `.Values.mq.RWX.storageClassName` for consistency with how `dns` is configured. Users of this Helm chart will be warned that they need to update their values.

Renamed the unused `postgresql-ha.postgresql.enabled` to `postgresql-ha.enabled` that controls the installation of PostgreSQL. Without this change it is `enabled=false`, consequently the PostgreSQL is not deployed, and you get the error:
```
[netmaker] Fatal: Error connecting to database:  dial tcp [::1]:5432: connect: connection refused
```