### PR TITLE
Enhance configuration options

### DIFF
--- a/templates/netmaker-statefulset.yaml
+++ b/templates/netmaker-statefulset.yaml
@@ -81,7 +81,14 @@ spec:
         - name: SQL_USER
           value: {{ index .Values "postgresql-ha" "postgresql" "username" }}
         - name: SQL_PASS
+        {{- if index .Values "postgresql-ha" "postgresql" "existingSecret" }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ index .Values "postgresql-ha" "postgresql" "existingSecret" }}
+              key: password
+        {{- else }}
           value: {{ index .Values "postgresql-ha" "postgresql" "password" }}
+        {{- end }}
         - name: DATABASE
           value: postgres
         - name: DISPLAY_KEYS
@@ -93,11 +100,32 @@ spec:
         - name: MQ_SERVER_PORT
           value: "1883"
         - name: MQ_ADMIN_PASSWORD
+        {{- if or (index .Values "mq" "existingSecretName") (index .Values "mq" "existingSecretKey") }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ index .Values "mq" "existingSecretName" }}
+              key: {{ index .Values "mq" "existingSecretKey" }}
+        {{- else }}
           value: {{ .Values.mq.password }}
+        {{- end }}
         - name: PLATFORM
           value: "Kubernetes"
         - name: VERBOSITY
           value: "3"
+        {{- if .Values.extraEnv }}
+          {{- tpl (.Values.extraEnv | toYaml) . | nindent 8 }}
+        {{- end }}
+        {{- if or .Values.extraEnvCM .Values.extraEnvSecret }}
+        envFrom:
+          {{- if .Values.extraEnvCM }}
+          - configMapRef:
+              name: {{ .Values.extraEnvCM }}
+          {{- end }}
+          {{- if .Values.extraEnvSecret }}
+          - secretRef:
+              name: {{ .Values.extraEnvSecret }}
+          {{- end }}
+        {{- end }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: {{ include "netmaker.fullname" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -34,6 +34,15 @@ podAnnotations: {}
 podSecurityContext: {}
 # fsGroup: 2000
 
+# -- extra environment variables from a config map
+# extraEnvCM: "configmap-name"
+# -- extra environment variables from a secret
+# extraEnvSecret: "secret-name"
+## -- extra environment variables, passed through helm tpl
+# extraEnv:
+#   - name: TEST_VARIABLE
+#     value: "TEST_VALUE"
+
 ui:
   # -- how many UI replicas to create
   replicas: 2
@@ -44,6 +53,10 @@ mq:
   singlenode: false
   storageSize: 128Mi
   password: 3yyerWGdds43yegGR
+  # -- specify a secret containing the mq password
+  # existingSecretName: ""
+  # -- key in the existing secret that contains the password for mq
+  # existingSecretKey: ""
   RWX:
     storageClassName: ""
 
@@ -121,10 +134,13 @@ postgresql-ha:
     username: netmaker
     # -- postgres pass to generate
     password: netmaker
-    # -- postgress db to generate
+    # -- postgres db to generate
     database: netmaker
-    # -- postgress number of replicas to deploy
+    # -- postgres number of replicas to deploy
     replicaCount: 2
+    # -- postgres use existing secret for passwords
+    # -- secret must contain values for keys postgres-password, password and repmgr-password
+    # existingSecret: ""
   persistence:
     # -- size of postgres DB
     size: 1Gi


### PR DESCRIPTION
Add option to include additional environment variables using the following methods:
* directly via `extraEnv`
* indirectly via `extraEnvCM` or `extraEnvSecret` 

Add option to use existing secrets for
* PostgreSQL passwords
* mq password

This solves #30 