### PR TITLE
fix: Fixing various bugs with existingClaim and endpoint URLs

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -27,12 +27,8 @@ metadata:
   {{- with .Values.ingress }}
   annotations:
     {{- toYaml .annotations.base | nindent 4 }}
-    {{- if or (eq .className "nginx") (eq .className "public") }}
-    {{- toYaml .annotations.nginx | nindent 4 }}
-    {{- end }}
-    {{- if eq .className "traefik" }}
-    {{- toYaml .annotations.traefik | nindent 4 }}
-    {{- end }}
+    {{- /* load class-specific annotations using className subkey */}}
+    {{- index .annotations .className | toYaml | nindent 4 }}
     {{- if and .tls.enabled (eq .tls.issuerName "" )}}
     {{- toYaml .annotations.tls | nindent 4 }}
     {{- else if .tls.enabled}}
@@ -88,12 +84,8 @@ metadata:
   {{- with .Values.ingress }}
   annotations:
     {{- toYaml .annotations.base | nindent 4 }}
-    {{- if or (eq .className "nginx") (eq .className "public") }}
-    {{- toYaml .annotations.nginx | nindent 4 }}
-    {{- end }}
-    {{- if eq .className "traefik" }}
-    {{- toYaml .annotations.traefik | nindent 4 }}
-    {{- end }}
+    {{- /* load class-specific annotations using className subkey */}}
+    {{- index .annotations .className | toYaml | nindent 4 }}
     {{- if and .tls.enabled (eq .tls.issuerName "" )}}
     {{- toYaml .annotations.tls | nindent 4 }}
     {{- else if .tls.enabled}}
@@ -133,7 +125,7 @@ spec:
               serviceName: {{ $fullRESTName }}
               servicePort: {{ $restSvcPort }}
               {{- end }}
-{{- if or (eq .Values.ingress.className "nginx") (eq .Values.ingress.className "public") }}
+{{- if or (eq .Values.ingress.className "nginx") (eq .Values.ingress.className "public") (contains "nginx" .Values.ingress.className) }}
 ---
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
@@ -188,7 +180,7 @@ spec:
               servicePort: {{ $mqSvcPort }}
               {{- end }}
 {{- end }}
-{{- if eq .Values.ingress.className "traefik" }}
+{{- if or (eq .Values.ingress.className "traefik") (contains "traefik" .Values.ingress.className) }}
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteTCP

--- a/templates/mq.yaml
+++ b/templates/mq.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         app: {{ include "netmaker.fullname" . }}-mqtt
     spec:
-      {{- if .Values.mq.singlenode }}    
+      {{- if .Values.mq.singlenode }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -30,7 +30,7 @@ spec:
       containers:
       - env:
         - name: NETMAKER_SERVER_HOST
-          value: https://api.{{ required "A valid .Values.baseDomain entry required!" .Values.baseDomain}}
+          value: https://{{ .Values.ingress.hostPrefix.rest }}{{ required "A valid .Values.baseDomain entry required!" .Values.baseDomain}}
         image: eclipse-mosquitto:2.0.11-openssl
         command: ["/mosquitto/config/wait.sh"]
         imagePullPolicy: Always
@@ -43,10 +43,10 @@ spec:
             port: 8883
           timeoutSeconds: 1
         ports:
-        - containerPort: 1883        
+        - containerPort: 1883
           name: mqtt
           protocol: TCP
-        - containerPort: 8883        
+        - containerPort: 8883
           name: mqtt2
           protocol: TCP
         readinessProbe:
@@ -85,9 +85,9 @@ spec:
         name: wait-script
       - name: shared-data
         persistentVolumeClaim:
-        {{- if not .Values.mq.existingClaim }}
+        {{- if .Values.mq.existingClaim }}
           claimName: {{ .Values.mq.existingClaim }}
-        {{- else }} 
+        {{- else }}
           claimName: {{ include "netmaker.fullname" . }}-shared-data-pvc
         {{- end }}
 ---
@@ -104,7 +104,7 @@ spec:
   - name: mqtt2
     port: 8883
     protocol: TCP
-    targetPort: mqtt2    
+    targetPort: mqtt2
   selector:
     app: {{ include "netmaker.fullname" . }}-mqtt
   sessionAffinity: None

--- a/templates/netmaker-statefulset.yaml
+++ b/templates/netmaker-statefulset.yaml
@@ -39,9 +39,9 @@ spec:
         - name: SERVER_NAME
           value: broker.{{ required "A valid .Values.baseDomain entry required!" .Values.baseDomain}}
         - name: SERVER_API_CONN_STRING
-          value: api.{{ required "A valid .Values.baseDomain entry required!" .Values.baseDomain}}:443
+          value: {{ .Values.ingress.hostPrefix.rest }}{{ required "A valid .Values.baseDomain entry required!" .Values.baseDomain}}:443
         - name: SERVER_HTTP_HOST
-          value: api.{{ required "A valid .Values.baseDomain entry required!" .Values.baseDomain}}
+          value: {{ .Values.ingress.hostPrefix.rest }}{{ required "A valid .Values.baseDomain entry required!" .Values.baseDomain}}
         - name: API_PORT
           value: "8081"
         {{- if not .Values.wireguard.kernel }}
@@ -127,7 +127,11 @@ spec:
       volumes:
       - name: shared-data
         persistentVolumeClaim:
+          {{- if .Values.persistence.existingClaim }}
+          claimName: {{ .Values.persistence.existingClaim }}
+          {{- else }}
           claimName: {{ include "netmaker.fullname" . }}-shared-data-pvc
+          {{- end }}
       {{- if .Values.dns.enabled }}
       - name: {{ include "netmaker.fullname" . }}-dns-pvc
         persistentVolumeClaim:

--- a/values.yaml
+++ b/values.yaml
@@ -34,6 +34,9 @@ podAnnotations: {}
 podSecurityContext: {}
 # fsGroup: 2000
 
+persistence:
+  existingClaim: ""
+
 ui:
   # -- how many UI replicas to create
   replicas: 2
@@ -46,6 +49,7 @@ mq:
   password: 3yyerWGdds43yegGR
   RWX:
     storageClassName: ""
+  existingClaim: ""
 
 dns:
   # -- whether or not to deploy coredns


### PR DESCRIPTION
Changes:
1. *(backwards compatible)* Make the ingress className configurable, used to 
have to be "nginx" or "traefik". Now will index values.yaml path 
ingress.annotations.<className> to pick up the map of annotations.
   - Note that "nginx" and "traefik" were already existing keys and happened 
   to also be the hardcoded className
2. *(backwards compatible)* Fixed hardcoded endpoint URLs to use the same 
values.yaml that already existed and was used to create the endpoint ingresses
3. *(backwards compatible)* Fixed a logic error for values.mq.existingClaim 
(incorrect `not` check)
4. *(backwards compatible)* Adding `.Values.persistence.existingClaim` for the 
netmaker statefulset. The default is `""`, which will use the pre-existing dynamic 
volume
5. *(backwards compatible)* Adding default to values.yaml for `mq.existingClaim: ""`