### PR TITLE
feat: add Gateway API HTTPRoute support & existing secret for DB credentials

### DIFF
--- a/templates/configmap.yml
+++ b/templates/configmap.yml
@@ -28,11 +28,13 @@ data:
   MQ_USERNAME: "{{ .Values.mq.username }}"
   LICENSE_KEY: "{{ .Values.server.ee.licensekey }}" # needed if EE 
   NETMAKER_TENANT_ID: "{{ .Values.server.ee.tenantId }}" # needed if EE
+  {{- if not .Values.db.existingSecret.enabled }}
   SQL_HOST: "{{ $dbHost }}"
   SQL_PORT: "{{ .Values.db.port }}"
   SQL_DB: "{{  .Values.db.database }}"
   SQL_USER: "{{ .Values.db.username }}"
   SQL_PASS: "{{ .Values.db.password }}"
+  {{- end }}
   SQL_SSL_MODE: "{{ .Values.db.sslmode }}"
   JWT_VALIDITY_DURATION: "{{ .Values.server.jwtDuration }}"
   RAC_AUTO_DISABLE: "{{ .Values.server.racAutoDisable }}"

--- a/templates/httproute.yaml
+++ b/templates/httproute.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "netmaker.fullname" . -}}
+{{- $fullUIName := printf "%s-%s" $fullName "ui" -}}
+{{- $fullRESTName := printf "%s-%s" $fullName "rest" -}}
+{{- $fullMQName := printf "%s-%s" $fullName "mqtt" -}}
+{{- $uiSvcPort := .Values.service.uiPort -}}
+{{- $restSvcPort := .Values.service.restPort -}}
+{{- $mqSvcPort := 8883 -}}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}-broker
+  labels:
+    {{- include "netmaker.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  hostnames:
+    - "{{ .Values.ingress.hostPrefix.broker }}.{{ .Values.baseDomain }}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ $fullMQName }}
+          port: {{ $mqSvcPort }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}-api
+  labels:
+    {{- include "netmaker.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  hostnames:
+    - "{{ .Values.ingress.hostPrefix.rest }}.{{ .Values.baseDomain }}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ $fullRESTName }}
+          port: {{ $restSvcPort }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}-dashboard
+  labels:
+    {{- include "netmaker.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  hostnames:
+    - "{{ .Values.ingress.hostPrefix.ui }}.{{ .Values.baseDomain }}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ $fullUIName }}
+          port: {{ $uiSvcPort }}
+{{- end }}

--- a/templates/mq.yaml
+++ b/templates/mq.yaml
@@ -28,6 +28,34 @@ spec:
         envFrom:
           - configMapRef:
               name: {{ include "netmaker.fullname" . }}-env
+        {{- if .Values.db.existingSecret.enabled }}
+        env:
+          - name: SQL_HOST
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.db.existingSecret.name }}
+                key: {{ .Values.db.existingSecret.keys.host }}
+          - name: SQL_PORT
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.db.existingSecret.name }}
+                key: {{ .Values.db.existingSecret.keys.port }}
+          - name: SQL_USER
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.db.existingSecret.name }}
+                key: {{ .Values.db.existingSecret.keys.username }}
+          - name: SQL_PASS
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.db.existingSecret.name }}
+                key: {{ .Values.db.existingSecret.keys.password }}
+          - name: SQL_DB
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.db.existingSecret.name }}
+                key: {{ .Values.db.existingSecret.keys.database }}
+        {{- end }}
         image: eclipse-mosquitto:2.0.11-openssl
         command: ["/mosquitto/config/wait.sh"]
         imagePullPolicy: Always

--- a/templates/netmaker-statefulset.yaml
+++ b/templates/netmaker-statefulset.yaml
@@ -20,6 +20,34 @@ spec:
               envFrom:
                 - configMapRef:
                     name: {{ include "netmaker.fullname" . }}-env
+              {{- if .Values.db.existingSecret.enabled }}
+              env:
+                - name: SQL_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.db.existingSecret.name }}
+                      key: {{ .Values.db.existingSecret.keys.host }}
+                - name: SQL_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.db.existingSecret.name }}
+                      key: {{ .Values.db.existingSecret.keys.port }}
+                - name: SQL_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.db.existingSecret.name }}
+                      key: {{ .Values.db.existingSecret.keys.username }}
+                - name: SQL_PASS
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.db.existingSecret.name }}
+                      key: {{ .Values.db.existingSecret.keys.password }}
+                - name: SQL_DB
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.db.existingSecret.name }}
+                      key: {{ .Values.db.existingSecret.keys.database }}
+              {{- end }}
               image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
               imagePullPolicy: {{ .Values.server.image.pullPolicy }}
               ports:

--- a/values.yaml
+++ b/values.yaml
@@ -144,7 +144,7 @@ db:
   # -- postgress db to generate
   database: netmaker
   # -- postgres sslmode (disable, require, verify-ca, verify-full)
-  sslmode: disable
+  sslmode: require
 
 postgresql-ha:
   # -- whether to install PostgreSQL HA as a dependency

--- a/values.yaml
+++ b/values.yaml
@@ -144,7 +144,19 @@ db:
   # -- postgress db to generate
   database: netmaker
   # -- postgres sslmode (disable, require, verify-ca, verify-full)
-  sslmode: require
+  sslmode: disable
+  # -- use an existing Kubernetes secret for DB credentials instead of values above
+  existingSecret:
+    enabled: false
+    # -- name of the existing secret
+    name: ""
+    # -- key mappings: maps each DB parameter to a key in the secret
+    keys:
+      host: "pgbouncer-host"
+      port: "pgbouncer-port"
+      username: "user"
+      password: "password"
+      database: "dbname"
 
 postgresql-ha:
   # -- whether to install PostgreSQL HA as a dependency

--- a/values.yaml
+++ b/values.yaml
@@ -122,6 +122,18 @@ ingress:
     ui: "dashboard"
     broker: "broker"
     rest: "api"
+
+gateway:
+  # -- create Gateway API HTTPRoutes instead of (or in addition to) Ingress
+  enabled: false
+  # -- annotations to add to HTTPRoute resources
+  annotations: {}
+  # -- parent Gateway references (list)
+  parentRefs:
+    - name: ""
+      namespace: ""
+      sectionName: https
+
 db:
   type: "postgres"
   host: ""


### PR DESCRIPTION
## Summary

- Adds native Kubernetes [Gateway API](https://gateway-api.sigs.k8s.io/) HTTPRoute support as an alternative (or complement) to traditional Ingress resources
- Adds `db.existingSecret` support to pull DB credentials from an existing Kubernetes secret (e.g. CrunchyData pguser secret) instead of hardcoding them in the ConfigMap
- Reverts `db.sslmode` default to `disable` to match upstream

## Changes

### 1. Gateway API HTTPRoute support

| File | Change |
|------|--------|
| `values.yaml` | Added `gateway` section (disabled by default) with `enabled`, `annotations`, and `parentRefs` fields |
| `templates/httproute.yaml` | New template — generates 3 `gateway.networking.k8s.io/v1` HTTPRoute resources |

New values:
```yaml
gateway:
  enabled: false
  annotations: {}
  parentRefs:
    - name: ""
      namespace: ""
      sectionName: https
```

- **Independent of Ingress:** `ingress.enabled` and `gateway.enabled` are fully independent — both can be true for migration scenarios
- **Reuses existing hostname values:** Hostnames come from `ingress.hostPrefix.{broker,rest,ui}` + `baseDomain`
- **No breaking changes:** Default `gateway.enabled: false` means existing deployments are unaffected

### 2. Existing Kubernetes secret for DB credentials

| File | Change |
|------|--------|
| `values.yaml` | Added `db.existingSecret` block with `enabled`, `name`, and `keys` sub-fields; reverted `db.sslmode` default to `disable` |
| `templates/configmap.yml` | Conditionally omit `SQL_HOST`/`SQL_PORT`/`SQL_DB`/`SQL_USER`/`SQL_PASS` when `existingSecret.enabled` is true (`SQL_SSL_MODE` always stays) |
| `templates/netmaker-statefulset.yaml` | Add conditional `env` entries with `secretKeyRef` that override ConfigMap values |
| `templates/mq.yaml` | Same conditional `env` block for the MQ deployment |

New values:
```yaml
db:
  existingSecret:
    enabled: false
    name: ""
    keys:
      host: "pgbouncer-host"
      port: "pgbouncer-port"
      username: "user"
      password: "password"
      database: "dbname"
```

- **Default key mappings match CrunchyData's pguser secret format** — users with different secrets can override individual key names
- **Backward compatible:** When `existingSecret.enabled` is false (default), behavior is identical to before
- **env overrides envFrom:** Kubernetes merges `envFrom` first, then `env` entries override, so the secret values take precedence over any ConfigMap values

## Test plan

- [ ] `helm template test .` with defaults — ConfigMap has all SQL_* keys, no secretKeyRef, no HTTPRoutes
- [ ] `helm template test . --set gateway.enabled=true --set 'gateway.parentRefs[0].name=my-gw'` — verify 3 HTTPRoute resources
- [ ] `helm template test . --set db.existingSecret.enabled=true --set db.existingSecret.name=postgres-pguser-usrnetmaker` — ConfigMap omits SQL creds, both StatefulSet and MQ Deployment have secretKeyRef entries
- [ ] `helm template test . --set db.existingSecret.enabled=true --set db.existingSecret.name=my-secret --set db.existingSecret.keys.host=my-host-key` — verify custom key mappings work